### PR TITLE
docs: add note about ffmpeg if missing ffprobe

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ make start-gradio-application
 
 This starts an interactive web interface where you can test the voice agent locally.
 
+> **_NOTE:_**  If you get the error 'No such file or directory: 'ffprobe', just install _ffmpeg_ in your system to solve it
+
 #### Option B: FastAPI Call Center (Production-Ready)
 
 For a production-ready setup that can receive real phone calls:


### PR DESCRIPTION
Adding solution for issue https://github.com/neural-maze/realtime-phone-agents-course/issues/1 to the README