### PR TITLE
Cache uv project dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,14 @@ RUN apt-get update && \
 
 WORKDIR /app
 
+# Use system Python instead of managing Python installations
+ENV UV_SYSTEM_PYTHON=1
+ENV UV_CACHE_DIR=/root/.cache/uv
+
 # Python deps
 COPY uv.lock pyproject.toml README.md ./
-RUN uv sync --frozen --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen
 
 # App code
 COPY src/realtime_phone_agents realtime_phone_agents/


### PR DESCRIPTION
Every time `pyproject.toml` changes all project dependencies (a couple of GB!) are re-downloaded by `uv` when rebuilding the api docker image. This PR enables dependency caching which stores the downloaded files in the local docker cache so that they are immediately available without re-download.

Additionally `uv` is prevented from downloading and installing a Python runtime and instead uses Python provided by the base image.
