### PR TITLE
Fix cuda versions not set

### DIFF
--- a/scripts/runpod/create_faster_whisper_pod.py
+++ b/scripts/runpod/create_faster_whisper_pod.py
@@ -12,6 +12,7 @@ pod = runpod.create_pod(
     name="Faster Whisper Server",
     image_name="theneuralmaze/faster-whisper-server:latest",
     gpu_type_id=settings.runpod.faster_whisper_gpu_type,
+    allowed_cuda_versions=["12.6", "12.7", "12.8", "12.9"],
     cloud_type="SECURE",
     gpu_count=1,
     volume_in_gb=20,


### PR DESCRIPTION
....which can lead to runpod.io assiging a GPU with an incompatible CUDA version:

<img width="2310" height="1639" alt="image" src="https://github.com/user-attachments/assets/76425e6a-841c-44ff-b542-8318e1fa94c5" />
